### PR TITLE
In-circuit assertion changes

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -210,17 +210,13 @@ impl Circuit {
                         )
                     })?;
 
-                // Specification interpretation verification: if this quad is part of Z, then its
-                // input wires should be coming from a Z gate, and should always be zero.
-                if quad_value.is_zero().into() {
+                let quad_output = if quad_value.is_zero().into() {
                     z_gate_indexes.insert(usize::from(quad.gate_index));
 
-                    if !bool::from((*left_wire * right_wire).is_zero()) {
-                        panic!("product of input wires to a Z quad should be zero");
-                    }
-                }
-
-                let quad_output = quad_value * left_wire * right_wire;
+                    *left_wire * right_wire
+                } else {
+                    quad_value * left_wire * right_wire
+                };
 
                 // Specification interpretation verification: this should never happen. We check
                 // this condition in roundtrip_circuit_test_vector, but not in deserialization.


### PR DESCRIPTION
This is a follow up to #5 and #9 to change how in-circuit assertions are handled and add tests using a handwritten circuit.

My interpretation of the spec is that we should only be checking if an output wire from the Z quad is zero after adding up all relevant terms, and not checking each quadratic term for equality with zero. The Z quad appears in the equation `0  = SUM_{l, r} Z[j][g, l, r] V[j + 1][l] V[j + 1][r]` in the spec, which illustrates this. I also downgraded in-circuit assertion failures from a panic to an error, since they may be triggered by inputs that don't satisfy a circuit.