### PR TITLE
error on nonzero Z quad inputs

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -216,7 +216,7 @@ impl Circuit {
                     z_gate_indexes.insert(usize::from(quad.gate_index));
 
                     if !bool::from((*left_wire * right_wire).is_zero()) {
-                        panic!("product of input wires to a Z quad should be zero");
+                        return Err(anyhow!("product of input wires to a Z quad should be zero"));
                     }
                 }
 


### PR DESCRIPTION
I missed a comment from @divergentdave in #5:

> This should be an error instead of a panic, since it can be triggered
> by an input that doesn't satisfy a circuit.

https://github.com/abetterinternet/zk-cred-rs/pull/5#discussion_r2377031310